### PR TITLE
Fix bug where @odata.count is always used for iCount

### DIFF
--- a/media/js/jquery.dataTables.odata.js
+++ b/media/js/jquery.dataTables.odata.js
@@ -105,7 +105,7 @@ function fnServerOData(sUrl, aoData, fnCallback, oSettings) {
 
             // Probe data structures for V4, V3, and V2 versions of OData response
             oDataSource.aaData = data.value || (data.d && data.d.results) || data.d;
-            var iCount = (data["@odata.count"] !== null) ? data["@odata.count"] : ((data["odata.count"] !== null) ? data["odata.count"] : ((data.__count !== null) ? data.__count : (data.d && data.d.__count)));
+            var iCount = (data["@odata.count"]) ? data["@odata.count"] : ((data["odata.count"]) ? data["odata.count"] : ((data.__count) ? data.__count : (data.d && data.d.__count)));
 
             if (iCount == null) {
                 if (oDataSource.aaData.length === oSettings._iDisplayLength) {


### PR DESCRIPTION
When `data["@odata.count"]` is undefined, the comparison `(data["@odata.count"] !== null)` returns 'true' and the fall through to the other cases in the ternary doesn't happen. 
