### PR TITLE
ASP.net WebAPI errors if $filter is empty and added the ability to extend the ajax settings

### DIFF
--- a/media/js/jquery.dataTables.odata.js
+++ b/media/js/jquery.dataTables.odata.js
@@ -88,7 +88,10 @@ function fnServerOData(sUrl, aoData, fnCallback, oSettings) {
                     }
                 }
             });
-        data.$filter = asFilters.join(" or ");
+			
+        if (asFilters.length > 0) {
+            data.$filter = asFilters.join(" or ");
+        }
 
         var asOrderBy = [];
         for (var i = 0; i < oParams.iSortingCols; i++) {

--- a/media/js/jquery.dataTables.odata.js
+++ b/media/js/jquery.dataTables.odata.js
@@ -18,7 +18,7 @@
  * 
  */
  
-function fnServerOData(sUrl, aoData, fnCallback, oSettings) {
+function fnServerOData(sUrl, aoData, fnCallback, oSettings, ajaxSettingOverrides) {
 
     var oParams = {};
     $.each(aoData, function (i, value) {
@@ -99,7 +99,8 @@ function fnServerOData(sUrl, aoData, fnCallback, oSettings) {
         }
         data.$orderby = asOrderBy.join();
     }
-    $.ajax({
+	
+	var ajaxSettings = {
         "url": sUrl,
         "data": data,
         "jsonp": bJSONP,
@@ -127,6 +128,10 @@ function fnServerOData(sUrl, aoData, fnCallback, oSettings) {
 
             fnCallback(oDataSource);
         }
-    });
+    };
+	
+    //take ajaxSettings and then merge it with ajaxSettingOverrides (purposefully a shallow merge as it's more predictable - it does not compare nested objects)
+	$.extend(ajaxSettings, ajaxSettingOverrides);
 
+    $.ajax(ajaxSettings);
 } // end fnServerData


### PR DESCRIPTION
If $filter is passed to 'ASP.net WebApi oData' and it is blank, then WebAPI errors.
This effects WebApi 1 (and probably v2+ as well).

This change checks if there are any filters first.
