### PR TITLE
Handle escaping of single quotes in search filters.

### DIFF
--- a/media/js/jquery.dataTables.odata.js
+++ b/media/js/jquery.dataTables.odata.js
@@ -82,11 +82,11 @@ function fnServerOData(sUrl, aoData, fnCallback, oSettings) {
                         {
                             // asFilters.push("substringof('" + oParams.sSearch + "', " + sFieldName + ")");
                             // substringof does not work in v4???
-                            asFilters.push("indexof(tolower(" + sFieldName + "), '" + oParams.sSearch.toLowerCase() + "') gt -1");
+                            asFilters.push("indexof(tolower(" + sFieldName + "), '" + oParams.sSearch.toLowerCase().replace(/'/g, "''") + "') gt -1");
                         }
 
                         if (columnFilter !== null && columnFilter !== "") {
-                            asColumnFilters.push("indexof(tolower(" + sFieldName + "), '" + columnFilter.toLowerCase() + "') gt -1");
+                            asColumnFilters.push("indexof(tolower(" + sFieldName + "), '" + columnFilter.toLowerCase().replace(/'/g, "''") + "') gt -1");
                         }
                         break;
 


### PR DESCRIPTION
We found a bug when typing single quotes into the search field.
Escaping the quotes fixes this problem.
